### PR TITLE
Read Corpus file line by line to avoid Buffer overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
         "codecov.io": "0.1.6",
         "istanbul": "0.3.20",
         "ghooks": "0.3.2",
-        "semantic-release": "^4.3.5"
+        "semantic-release": "^4.3.5",
+        "n-readlines": "0.2.7"
     },
     "czConfig": {
         "path": "node_modules/cz-conventional-changelog"

--- a/src/index.js
+++ b/src/index.js
@@ -2,17 +2,40 @@ module.exports = {
     text2token: text2token
 }
 
+Array.prototype.contains = function(v) {
+    for(var i = 0; i < this.length; i++) {
+        if(this[i] === v) return true;
+    }
+    return false;
+};
+
+Array.prototype.unique = function() {
+    var arr = [];
+    for(var i = 0; i < this.length; i++) {
+        if(!arr.contains(this[i])) {
+            arr.push(this[i]);
+        }
+    }
+    return arr; 
+}
+
 function text2token(textFile) {
     var lines = [],
         tokens = [];
 
+   
     var fs = require('fs');
+    //Read Corpus line by line
+    var lineByLine = require('n-readlines');
 
     if (textFile == '' || textFile == undefined) {
         throw new Error('path is required');
     }
 
-    var lines = fs.readFileSync(textFile).toString().split("\n");
+    var liner = new lineByLine(textFile);
+    while (line = liner.next()) {
+        lines.push(line.toString('ascii'));
+    }
 
     for (var i = 0; i < lines.length; i++) {
         var words = lines[i].split(" ");
@@ -23,25 +46,5 @@ function text2token(textFile) {
 
     tokens = tokens.unique();
 
-    return {
-        lines: lines,
-        tokens: tokens
-    }
-}
-
-Array.prototype.contains = function(v) {
-    for (var i = 0; i < this.length; i++) {
-        if (this[i] === v) return true;
-    }
-    return false;
-};
-
-Array.prototype.unique = function() {
-    var arr = [];
-    for (var i = 0; i < this.length; i++) {
-        if (!arr.contains(this[i])) {
-            arr.push(this[i]);
-        }
-    }
-    return arr;
+    return {lines: lines, tokens:tokens}
 }


### PR DESCRIPTION
The corpora files are generally large and exceed the standard Buffer length (https://github.com/nodejs/node/issues/3175). When converting the buffer from the `readFileSync()` to string using `toString()`, the app crashes due to memory constraints (see [issue](https://github.com/nodejs/node/issues/3175)).

The fix is to read the corpus line by line (in sync), perform `toString()` and push this line to the array `lines`.
